### PR TITLE
Add line information export to name-as

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ name-ext/node_modules/*
 *.o
 !name-as/.artifacts/*
 name-fmt/node_modules/
+*.li

--- a/name-as/Makefile
+++ b/name-as/Makefile
@@ -24,7 +24,7 @@ run-gnu: build
 	$(CARGO) run -- $(GNUCFG) $(INPUT) $(OUTPUT)
 
 test: run
-	$(CARGO) run $(GNUCFG) $(INPUT) gnu-$(OUTPUT)
+	$(CARGO) run -- $(GNUCFG) $(INPUT) gnu-$(OUTPUT)
 	md5sum $(OUTPUT) gnu-$(OUTPUT)
 
 clean:

--- a/name-as/Makefile
+++ b/name-as/Makefile
@@ -18,10 +18,10 @@ build: fmt
 	$(CARGO) build
 
 run: build
-	$(CARGO) run $(CONFIG) $(INPUT) $(OUTPUT)
+	$(CARGO) run -- -l $(CONFIG) $(INPUT) $(OUTPUT)
 
 run-gnu: build
-	$(CARGO) run $(GNUCFG) $(INPUT) $(OUTPUT)
+	$(CARGO) run -- $(GNUCFG) $(INPUT) $(OUTPUT)
 
 test: run
 	$(CARGO) run $(GNUCFG) $(INPUT) gnu-$(OUTPUT)

--- a/name-as/src/args.rs
+++ b/name-as/src/args.rs
@@ -5,15 +5,19 @@ pub struct Args {
     pub config_fn: String,
     pub input_as: String,
     pub output_as: String,
+    pub line_info: bool,
 }
 
 fn help() {
-    println!("Usage: name CONFIG INPUT OUTPUT\n");
+    println!("Usage: name [OPTIONS] CONFIG INPUT OUTPUT\n");
     println!("Required:");
     println!("  CONFIG       A toml configuration file, examples");
     println!("               are provided in configs/");
     println!("  INPUT_AS     An input assembly file");
     println!("  OUTPUT_AS    An output assembled file");
+    println!("Optional:");
+    println!("  --lineinfo");
+    println!("   -l          Enables line information export");
 }
 
 pub fn parse_args() -> Result<Args, &'static str> {
@@ -21,21 +25,42 @@ pub fn parse_args() -> Result<Args, &'static str> {
         config_fn: String::new(),
         input_as: String::new(),
         output_as: String::new(),
+        line_info: false,
     };
     let args_strings: Vec<String> = env::args().collect();
 
-    if args_strings.len() != 4 {
+    if args_strings.len() < 4 {
         help();
         return Err("Incorrect number of arguments");
     }
 
-    for (i, arg) in args_strings.iter().enumerate().skip(1) {
-        match i {
+    let mut arg_index = 1;
+    for arg in args_strings.iter().skip(1) {
+        let mut parsed_option = true;
+        match arg.as_str() {
+            "-l" | "--lineinfo" => args.line_info = true,
+            _ => parsed_option = false,
+        };
+        if parsed_option {
+            continue;
+        }
+
+        match arg_index {
             1 => args.config_fn = arg.to_string(),
             2 => args.input_as = arg.to_string(),
             3 => args.output_as = arg.to_string(),
             _ => return Err("Argument out of bounds"),
         }
+
+        arg_index += 1;
+    }
+
+    if args.config_fn == String::new() {
+        return Err("Expected a configuration file but found none");
+    } else if args.input_as == String::new() {
+        return Err("Expected an input assembly file but found none");
+    } else if args.output_as == String::new() {
+        return Err("Expected an output assembly file but found none");
     }
 
     Ok(args)

--- a/name-as/src/lineinfo.rs
+++ b/name-as/src/lineinfo.rs
@@ -1,0 +1,29 @@
+extern crate serde;
+extern crate toml;
+use serde::Serialize;
+
+use std::fs;
+
+#[derive(Debug, Serialize)]
+pub struct LineInfo {
+    pub instr_addr: u32,
+    pub line_number: u32,
+    pub line_contents: String,
+    pub psuedo_op: String,
+}
+
+#[derive(Serialize)]
+struct LineInfoFile {
+    pub lineinfo: Vec<LineInfo>,
+}
+
+pub fn lineinfo_export(
+    filename: String,
+    li: Vec<LineInfo>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let toml_data = toml::to_string(&LineInfoFile { lineinfo: li })?;
+
+    fs::write(filename, toml_data)?;
+
+    Ok(())
+}

--- a/name-as/src/main.rs
+++ b/name-as/src/main.rs
@@ -3,6 +3,7 @@ extern crate pest_derive;
 
 pub mod args;
 pub mod config;
+pub mod lineinfo;
 
 pub mod nma;
 pub mod parser;
@@ -11,7 +12,7 @@ use args::parse_args;
 use nma::assemble;
 use std::process::Command;
 
-fn main() -> Result<(), &'static str> {
+fn main() -> Result<(), String> {
     // Parse command line arguments and the config file
     let cmd_args = parse_args()?;
 
@@ -54,7 +55,7 @@ fn main() -> Result<(), &'static str> {
                 }
                 Err(err) => {
                     eprintln!("CMD {}\nError: {}", full_cmd, err);
-                    return Err("Failed to run assembler command");
+                    return Err("Failed to run assembler command".to_string());
                 }
             }
         }

--- a/name-as/src/nma.rs
+++ b/name-as/src/nma.rs
@@ -494,6 +494,7 @@ pub fn assemble(program_arguments: &Args) -> Result<(), String> {
 
     // Assign addresses to labels
     let mut current_addr: u32 = TEXT_ADDRESS_BASE;
+    let mut line_number: u32 = 1;
     let mut labels: HashMap<&str, u32> = HashMap::new();
     for sub_cst in &vernac_sequence {
         match sub_cst {
@@ -518,7 +519,7 @@ pub fn assemble(program_arguments: &Args) -> Result<(), String> {
                 // Update line info
                 lineinfo.push(LineInfo {
                     instr_addr: current_addr,
-                    line_number: 0,
+                    line_number: line_number,
                     line_contents: instr_to_str(mnemonic, &args),
                     psuedo_op: "".to_string(),
                 });
@@ -569,6 +570,7 @@ pub fn assemble(program_arguments: &Args) -> Result<(), String> {
         };
 
         current_addr += MIPS_INSTR_BYTE_WIDTH;
+        line_number += 1;
     }
 
     if program_arguments.line_info {

--- a/name-as/src/nma.rs
+++ b/name-as/src/nma.rs
@@ -1,5 +1,6 @@
 /// NAME Mips Assembler
 use crate::args::Args;
+use crate::lineinfo::*;
 use crate::parser::print_cst;
 use std::collections::HashMap;
 use std::fs;
@@ -456,20 +457,20 @@ use crate::parser::*;
 use pest::Parser;
 
 // General assembler entrypoint
-pub fn assemble(args: &Args) -> Result<(), &'static str> {
+pub fn assemble(program_arguments: &Args) -> Result<(), String> {
     // IO Setup
-    let input_fn = &args.input_as;
-    let output_fn = &args.output_as;
+    let input_fn = &program_arguments.input_as;
+    let output_fn = &program_arguments.output_as;
 
     let output_file: File = match File::create(output_fn) {
         Ok(v) => v,
-        Err(_) => return Err("Failed to open output file"),
+        Err(_) => return Err("Failed to open output file".to_string()),
     };
 
     // Read input
     let file_contents: String = match fs::read_to_string(input_fn) {
         Ok(v) => v,
-        Err(_) => return Err("Failed to read input file contents"),
+        Err(_) => return Err("Failed to read input file contents".to_string()),
     };
 
     // Parse into CST
@@ -480,6 +481,10 @@ pub fn assemble(args: &Args) -> Result<(), &'static str> {
             .unwrap(),
     );
     print_cst(&cst);
+
+    // Set up line info
+    let lineinfo_fn = format!("{}.li", &program_arguments.output_as);
+    let mut lineinfo: Vec<LineInfo> = vec![];
 
     let vernac_sequence: Vec<MipsCST> = if let MipsCST::Sequence(v) = cst {
         v
@@ -510,6 +515,14 @@ pub fn assemble(args: &Args) -> Result<(), &'static str> {
     for sub_cst in vernac_sequence {
         match sub_cst {
             MipsCST::Instruction(mnemonic, args) => {
+                // Update line info
+                lineinfo.push(LineInfo {
+                    instr_addr: current_addr,
+                    line_number: 0,
+                    line_contents: instr_to_str(mnemonic, &args),
+                    psuedo_op: "".to_string(),
+                });
+
                 if let Ok(instr_info) = r_operation(mnemonic) {
                     println!("-----------------------------------");
                     println!(
@@ -519,10 +532,10 @@ pub fn assemble(args: &Args) -> Result<(), &'static str> {
                     match assemble_r(instr_info, args) {
                         Ok(assembled_r) => {
                             if write_u32(&output_file, assembled_r).is_err() {
-                                return Err("Failed to write to output binary");
+                                return Err("Failed to write to output binary".to_string());
                             }
                         }
-                        Err(e) => return Err(e),
+                        Err(e) => return Err(e.to_string()),
                     }
                 } else if let Ok(instr_info) = i_operation(mnemonic) {
                     println!("-----------------------------------");
@@ -531,10 +544,10 @@ pub fn assemble(args: &Args) -> Result<(), &'static str> {
                     match assemble_i(instr_info, args, &labels, current_addr) {
                         Ok(assembled_i) => {
                             if write_u32(&output_file, assembled_i).is_err() {
-                                return Err("Failed to write to output binary");
+                                return Err("Failed to write to output binary".to_string());
                             }
                         }
-                        Err(e) => return Err(e),
+                        Err(e) => return Err(e.to_string()),
                     }
                 } else if let Ok(instr_info) = j_operation(mnemonic) {
                     println!("-----------------------------------");
@@ -543,19 +556,25 @@ pub fn assemble(args: &Args) -> Result<(), &'static str> {
                     match assemble_j(instr_info, args, &labels) {
                         Ok(assembled_j) => {
                             if write_u32(&output_file, assembled_j).is_err() {
-                                return Err("Failed to write to output binary");
+                                return Err("Failed to write to output binary".to_string());
                             }
                         }
-                        Err(e) => return Err(e),
+                        Err(e) => return Err(e.to_string()),
                     }
                 } else {
-                    return Err("Failed to match instruction");
+                    return Err("Failed to match instruction".to_string());
                 }
             }
             _ => continue,
         };
 
         current_addr += MIPS_INSTR_BYTE_WIDTH;
+    }
+
+    if program_arguments.line_info {
+        if let Err(e) = lineinfo_export(lineinfo_fn, lineinfo) {
+            return Err(e.to_string());
+        }
     }
 
     Ok(())

--- a/name-as/src/parser.rs
+++ b/name-as/src/parser.rs
@@ -69,6 +69,6 @@ pub fn print_cst(cst: &MipsCST) {
     }
 }
 
-pub fn instr_to_str(mnemonic: &str, args: &Vec<&str>) -> String {
+pub fn instr_to_str(mnemonic: &str, args: &[&str]) -> String {
     format!("{} {}", mnemonic, args.join(" "))
 }

--- a/name-as/src/parser.rs
+++ b/name-as/src/parser.rs
@@ -68,3 +68,7 @@ pub fn print_cst(cst: &MipsCST) {
         }
     }
 }
+
+pub fn instr_to_str(mnemonic: &str, args: &Vec<&str>) -> String {
+    format!("{} {}", mnemonic, args.join(" "))
+}


### PR DESCRIPTION
Generates a file with the filename pattern `output_assembly_fn.li`, just contains TOML data for the following `LineInfoFile` struct (yes, it was required to add the second struct, the vec isn't serializable on its own according to Serde)

```rust
#[derive(Debug, Serialize)]
pub struct LineInfo {
    pub instr_addr: u32,
    pub line_number: u32,
    pub line_contents: String,
    pub psuedo_op: String,
}

#[derive(Serialize)]
struct LineInfoFile {
    pub lineinfo: Vec<LineInfo>,
}
```

Pseudoop field never gets filled currently, will when we compile a list of pseudoops

Line number field is really instruction number field, need to look into Serde to get real line number info